### PR TITLE
Update containers from Ubuntu 16.04 to 18.04

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial AS base
+FROM ubuntu:bionic AS base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \

--- a/Dockerfile.amd64.debug
+++ b/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial AS base
+FROM ubuntu:bionic AS base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common gdb && \
     add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:xenial AS base
+FROM arm32v7/ubuntu:bionic AS base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:xenial AS base
+FROM arm64v8/ubuntu:bionic AS base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:aziotsdklinux/ppa-azureiot && \


### PR DESCRIPTION
IoT Edge no longer supports Ubuntu 16.04 and customers have
reported bugs related to the associated version of openssl (1.0).
These issues go away when using Ubuntu 18.04, which is associated
with openssl 1.1.